### PR TITLE
Refactored to use through2-filter and then allowed key store to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,29 @@ makeStreamOfObjects()
 
 aggregator.on('data', console.log);
 ```
+
+## Use a custom store to record keys that have been encountered
+
+By default a set is used to store keys encountered so far, in order to check new ones for
+uniqueness. You can supply your own store instead, providing it supports the add(key) and 
+has(key) methods. This could allow you to use a persistant store so that already encountered
+objects are not re-streamed when node is reloaded.
+
+``` js
+var keyStore = {
+  store: {},
+
+  add: function(key) {
+    this.store[key] = true;
+  },
+
+  has: function(key) {
+    return this.store[key] !== undefined;
+  }
+};
+    
+makeStreamOfObjects()
+  .pipe(unique('name', keyStore))
+  .on('data', console.log);
+```
+

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ function unique(propName, keyStore) {
   return filter(function (data) {
     var key = keyfn(data);
 
-    if (set.has(key)) {
+    if (keyStore.has(key)) {
       return false
     } else {
-      set.add(key);
+      keyStore.add(key);
       return true
     }
   });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Stream = require('stream');
+var filter = require("through2-filter").obj
 
 function prop(propName) {
   return function (data) {
@@ -14,41 +14,16 @@ function unique(propName) {
   } else if (typeof propName === 'function') {
     keyfn = propName;
   }
-  var seen = {};
-  var s = new Stream();
-  s.readable = true;
-  s.writable = true;
-  var pipes = 0;
 
-  s.write = function (data) {
+  var seen = {};
+
+  return filter(function (data) {
     var key = keyfn(data);
     if (seen[key] === undefined) {
       seen[key] = true;
-      s.emit('data', data);
+      return true
+    } else {
+      return false
     }
-  };
-
-  var ended = 0;
-  s.end = function (data) {
-    if (arguments.length) s.write(data);
-    ended++;
-    if (ended === pipes || pipes === 0) {
-      s.writable = false;
-      s.emit('end');
-    }
-  };
-
-  s.destroy = function (data) {
-    s.writable = false;
-  };
-
-  s.on('pipe', function () {
-    pipes++;
   });
-
-  s.on('unpipe', function () {
-    pipes--;
-  });
-
-  return s;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var filter = require("through2-filter").obj
+var filter = require("through2-filter").obj;
 var Set = require('es6-set');
 
 function prop(propName) {
@@ -22,10 +22,10 @@ function unique(propName, keyStore) {
     var key = keyfn(data);
 
     if (keyStore.has(key)) {
-      return false
+      return false;
     } else {
       keyStore.add(key);
-      return true
+      return true;
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var filter = require("through2-filter").obj
+var Set = require('es6-set');
 
 function prop(propName) {
   return function (data) {
@@ -7,7 +8,9 @@ function prop(propName) {
 }
 
 module.exports = unique;
-function unique(propName) {
+function unique(propName, keyStore) {
+  keyStore = keyStore || new Set();
+
   var keyfn = JSON.stringify;
   if (typeof propName === 'string') {
     keyfn = prop(propName);
@@ -15,15 +18,14 @@ function unique(propName) {
     keyfn = propName;
   }
 
-  var seen = {};
-
   return filter(function (data) {
     var key = keyfn(data);
-    if (seen[key] === undefined) {
-      seen[key] = true;
-      return true
-    } else {
+
+    if (set.has(key)) {
       return false
+    } else {
+      set.add(key);
+      return true
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "after": "~0.8.1"
   },
   "dependencies": {
+    "es6-set": "^0.1.1",
     "through2-filter": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "chai": "~1.7.2",
     "mocha": "^1.18.2",
     "after": "~0.8.1"
+  },
+  "dependencies": {
+    "through2-filter": "^1.4.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -106,4 +106,34 @@ describe('unique stream', function() {
     stream.write('hello');
     stream.end();
   });
+
+  it('can use a custom keystore', function(done) {
+    var keyStore = {
+      store: {},
+
+      add: function(key) {
+        this.store[key] = true;
+      },
+
+      has: function(key) {
+        return this.store[key] !== undefined;
+      }
+    };
+
+    var aggregator = unique('number', keyStore);
+    makeStream('a')
+      .pipe(aggregator);
+    makeStream('b')
+      .pipe(aggregator);
+
+    var n = 0;
+    aggregator
+      .on('data', function () {
+        n++;
+      })
+      .on('end', function () {
+        expect(n).to.equal(10);
+        done();
+      });
+  })
 });


### PR DESCRIPTION
Hi Eugene, I wanted a version of unique-stream which wouldn't lose it's store of keys if I restarted node, so I've modified you library to take in keyStore as an optional parameter. In order to give it a nice interface, I'm asking for any object with has(key) and and(key) methods, and for the default store I'm using the es6-set library. Alternatively, in the example in the readme and in my additional test I provide an example of using your original object based store.

While doing this, I also thought the code might be simpler if I used through2-stream to handle all the complex stream stuff. That was a fairly major refactoring, but your tests all still pass, and it's greatly reduced the length of the code, and I think better exposes the intent, because it leaves the important bit (filtering objects based on whether the key has been seen before) and hides all the stream stuff. 

I'd be keen to know whether you'd be interested in merging this in. I haven't bumped the version number as yet. This change should be fully backward compatible, but to be honest I can't say with full certainty that through2-filter doesn't have some quirks in areas that aren't covered by your tests.