### PR TITLE
Use smallest possible Set polyfill to reduce package file size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - iojs
+  - node
+  - '0.10'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
+'use strict';
+
 var filter = require('through2-filter').obj;
-var Set = require('es6-set');
+var ES6Set;
+if (typeof global.Set === 'function') {
+  ES6Set = global.Set;
+} else {
+  ES6Set = function() {
+    this.keys = [];
+    this.has = function(val) {
+      return this.keys.indexOf(val) !== -1;
+    },
+    this.add = function(val) {
+      this.keys.push(val);
+    }
+  }
+}
 
 function prop(propName) {
   return function (data) {
@@ -9,7 +24,7 @@ function prop(propName) {
 
 module.exports = unique;
 function unique(propName, keyStore) {
-  keyStore = keyStore || new Set();
+  keyStore = keyStore || new ES6Set();
 
   var keyfn = JSON.stringify;
   if (typeof propName === 'string') {
@@ -23,9 +38,9 @@ function unique(propName, keyStore) {
 
     if (keyStore.has(key)) {
       return false;
-    } else {
-      keyStore.add(key);
-      return true;
     }
+
+    keyStore.add(key);
+    return true;
   });
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "node.js through stream that emits a unique stream of objects based on criteria",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -19,13 +19,12 @@
   ],
   "author": "Eugene Ware <eugene@noblesamurai.com>",
   "license": "BSD",
+  "dependencies": {
+    "through2-filter": "^1.4.0"
+  },
   "devDependencies": {
     "after": "~0.8.1",
-    "chai": "^1.10.0",
+    "chai": "^3.0.0",
     "mocha": "^2.1.0"
-  },
-  "dependencies": {
-    "es6-set": "^0.1.1",
-    "through2-filter": "^1.4.0"
   }
 }


### PR DESCRIPTION
I replaced [es6-set](https://github.com/medikoo/es6-set) module with a hard-coded tiny [Set](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set) polyfill. The polyfill only supports the `.has` and `.add` methods, but there's no problems with it since this module uses just those two methods.

Usually I prefer [modular programming](https://en.wikipedia.org/wiki/Modular_programming) and always try to create my software with various small npm modules. The reason why I added such a hard-coded thing though is the huge file size of `es6-set` module (*over 3.9MB!*).

The current latest version on npm (2.0.2):

```
$ npm install unique-stream@2.0.2
$ du -sh node_modules/unique-stream
> 4.0M	node_modules/unique-stream
```

After merging this PR:

```
$ npm install eugeneware/unique-stream#0660f7a7a33375cf4f8e8d5495d0307608c46480
$ du -sh node_modules/unique-stream
> 300K	node_modules/unique-stream
```

As you can see, this PR reduces a lot of package file size. It would help many [gulp.js](http://gulpjs.com/) users because [glob-stream](https://github.com/wearefractal/glob-stream), used in [gulp's file system](https://github.com/wearefractal/vinyl-fs), depends on unique-stream. https://github.com/wearefractal/glob-stream/blob/799c843870735021613b37fb486b7545a6cb3ea0/package.json#L16
