### PR TITLE
Fix dependence on object key order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var filter = require('through2-filter').obj;
+var stringify = require("json-stable-stringify");
 var ES6Set;
 if (typeof global.Set === 'function') {
   ES6Set = global.Set;
@@ -26,7 +27,7 @@ module.exports = unique;
 function unique(propName, keyStore) {
   keyStore = keyStore || new ES6Set();
 
-  var keyfn = JSON.stringify;
+  var keyfn = stringify;
   if (typeof propName === 'string') {
     keyfn = prop(propName);
   } else if (typeof propName === 'function') {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "streams"
   ],
   "dependencies": {
+    "json-stable-stringify": "^1.0.0",
     "through2-filter": "^2.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -11,18 +11,28 @@ describe('unique stream', function() {
     s.readable = true;
 
     var n = 10;
-    var next = after(n, function () {
+    var next = after(n * 2, function () {
       setImmediate(function () {
         s.emit('end');
       });
     });
 
-    for (var i = 0; i < n; i++) {
-      var o = {
-        type: type,
-        name: 'name ' + i,
-        number: i * 10
-      };
+    for (var k = 0; k < n * 2; k++) {
+      var i = Math.floor(k / 2);
+      var o;
+      if (k % 2 === 0) {
+        o = {
+          type: type,
+          name: 'name ' + i,
+          number: i * 10,
+        };
+      } else {
+        o = {
+          number: i * 10,
+          name: 'name ' + i,
+          type: type,
+        };
+      }
 
       (function (o) {
         setImmediate(function () {


### PR DESCRIPTION
`JSON.stringify` is non-deterministic and can produce different output for the "same" object:

> Properties of non-array objects are not guaranteed to be stringified in any particular order. Do not rely on ordering of properties within the same object within the stringification. [1]
> — [`JSON.stringify` on MDN][1]

This changes to use *[json-stable-stringify][2]*, a deterministic implementation of `JSON.stringify`.

This also modifies tests to include objects that have the same values, but with different key order. These tests failed before making the change to use *json-stable-strinigfy*.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
[2]: https://www.npmjs.com/package/json-stable-stringify