### PR TITLE
Remove dependency on jsonify by using json-stable-stringify-without-jsonify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var filter = require('through2-filter').obj;
-var stringify = require("json-stable-stringify");
+var stringify = require("json-stable-stringify-without-jsonify");
 
 var ES6Set;
 if (typeof global.Set === 'function') {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "streams"
   ],
   "dependencies": {
-    "json-stable-stringify": "^1.0.0",
+    "json-stable-stringify-without-jsonify": "^1.0.1",
     "through2-filter": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`jsonify` is unfortunately not licensed under a recognised open source license which causes issues in some enterprises. Since `jsonify` is not actually needed, it can simply be dropped by using `json-stable-stringify-without-jsonify`. Also makes the install size a little smaller :)